### PR TITLE
Script create zip package

### DIFF
--- a/maintainers/zippackage.sh
+++ b/maintainers/zippackage.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # shebang.
 
 # Path from which to download simopt
-SIMOPT_URL='https://raw.githubusercontent.com/Tsjerk/simopt/master/simopt/__init__.py'
+SIMOPT_URL='https://raw.githubusercontent.com/Tsjerk/simopt/master/simopt.py'
 
 # Zip is annoying when it comes to path inside the archive.
 # We make a copy of the repository that we can modify without worrying to much.
@@ -36,12 +36,12 @@ EOF
 zip -r insane.zip *
 
 # Make it executable
-echo '#!/usr/bin/env python' | cat - insane.zip > insane
-chmod +x insane
+echo '#!/usr/bin/env python' | cat - insane.zip > package
+chmod +x package
 
 # Clean the mess
 cd ../
-mv build/insane ./
+mv build/package ./insane
 rm -rf build
 
 # Were are done. Let's say good bye.

--- a/maintainers/zippackage.sh
+++ b/maintainers/zippackage.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build a zip package of insane
+#
+# In order to be easily used from the command line without installation, while
+# being modular for developers and library users, we distribute insane an
+# executable zip. That zip can be called directly from the command line (e.g.
+# `./insane -h`) or through python (e.g. `python insane -h`).
+#
+# The distributed zip is a zipped version of the repository prepended with a
+# shebang.
+
+# Path from which to download simopt
+SIMOPT_URL='https://raw.githubusercontent.com/Tsjerk/simopt/master/simopt/__init__.py'
+
+# Zip is annoying when it comes to path inside the archive.
+# We make a copy of the repository that we can modify without worrying to much.
+mkdir -p build
+rsync -ruv ../* build --exclude 'tests' --exclude 'maintainers'
+cd build
+
+# Download simopt
+wget "${SIMOPT_URL}" -O simopt.py
+
+# __main__.py is the entry point of the script. We do not want it in the
+# module as it makes no sense to have it there, so we write it here.
+cat << EOF > __main__.py
+import sys
+import insane
+
+sys.exit(insane.main(sys.argv))
+EOF
+
+# Actually make the zip file. Finally!
+zip -r insane.zip *
+
+# Make it executable
+echo '#!/usr/bin/env python' | cat - insane.zip > insane
+chmod +x insane
+
+# Clean the mess
+cd ../
+mv build/insane ./
+rm -rf build
+
+# Were are done. Let's say good bye.
+echo 'The zip package is created. Try `./insane -h`.'


### PR DESCRIPTION
We want to make a module of insane that would be split in multiple
files. Already we depend on simopt, so the parsing of the arguments in
factored out of insane.py.

This makes insane more difficult to use for users that are not familiar
with installing python modules using pip.

A solution to this problem is to distribute insane as a zipped package.
That package is a zip file that can be executed by python. The only
constraint is that the zip file must contain a __main__.py, then it can
be called from the command line as `python insane.zip`. Adding a shebang
on top of the file allows to execute directly `./insane.zip`.

This commit introduces `zippackage.sh` that creates such a zip package
for insane. The zip package is simply named `insane` as the zip
extension would be confusing for most users. The script downloads the
latest version of simopt from github and includes it in the package.

Note that `zippackage.sh` *must* be executed from the 'maintainers'
directory!

The package is build in the 'maintainers' directory and can be tested
with `./insane -h`.