### PR TITLE
Configure travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: python
+env:
+    matrix:
+        - BUILD="test"
+        - BUILD="package"
+install:
+    - |
+        if [[ $BUILD == 'test' ]]; \
+        then \
+        git clone https://github.com/Tsjerk/simopt.git && pip install ./simopt; \
+        fi
+    - |
+        if [[ $BUILD == 'test' ]]; \
+        then \
+        pip install ./ ; \
+        fi
+    - |
+        if [[ $BUILD == 'test' ]]; \
+        then \
+        pip install nose; \
+        fi
+script:
+    - |
+        if [[ $BUILD == 'test' ]]; \
+        then \
+        cd tests && nosetests -v; \
+        fi
+    - |
+        if [[ $BUILD == 'package' ]]; \
+        then \
+        cd maintainers && ./zippackage.sh && ./insane -h; \
+        fi


### PR DESCRIPTION
TravisCI is a continuous integration service. After every push, the
service is triggered from github by a hook, and travis run the tests.
This allows to make sure pull requests do not break the code, and to
know at any time if the current version if broken or not.

This commit adds a configuration file for TravisCI. It declares two
build job to run for every commit:
* one job (BUILD='test') installs simopt and insanem and run the
  regression tests;
* the other job (BUILD='package') do not install anything, but builds
  the zipped package and make sure it runs (./insane -h).

For TravisCI to be active, @Tsjerk must create an account on the
service, and active bulds for Insane. This can be done on
<https://travis-ci.org>.

An example run is visible for my fork:
<https://travis-ci.org/jbarnoud/Insane/builds>. The build is currently
broken until <https://github.com/Tsjerk/simopt/pull/3> is merged.