### PR TITLE
Test GRO file equality based on semantics

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -19,16 +19,20 @@ from __future__ import print_function
 
 from nose.tools import assert_equal, assert_raises
 
+from collections import namedtuple
+import copy
 import contextlib
 import functools
 import glob
 import itertools
 import os
+import math
 import shutil
 import shlex
 import subprocess
 import sys
 import tempfile
+import textwrap
 
 from StringIO import StringIO
 
@@ -112,6 +116,23 @@ for pbc in ('hexagonal', 'rectangular', 'square', 'cubic', 'optimal'):
         '-o test.gro -disc 8 -hole 4 -pbc {} -d 10'.format(pbc),
     ])
 
+# GRO file format description. The key is the name of the field, the value is a
+# tuple from which the first element is the first (included) and last
+# (excluded) indices of the field in the line, and the second element the type
+# of the field content.
+GRO_FIELDS = {
+    "resid": ((0, 5), int),
+    "resname": ((5, 10), str),
+    "name": ((10, 15), str),
+    "index": ((15, 20), int),
+    "x": ((20, 28), float),
+    "y": ((28, 36), float),
+    "z": ((36, 44), float),
+}
+GRO_TEMPLATE = '{resid:>5}{resname:<5}{name:>5}{index:>5}{x:8.3f}{y:8.3f}{z:8.3f}'
+
+GroDiff = namedtuple('GroDiff', 'linenum line ref_line fields')
+
 
 class ContextStringIO(StringIO):
     """
@@ -172,6 +193,199 @@ def _arguments_as_list(arguments):
     except ValueError:
         arguments_list = arguments
     return arguments_list
+
+
+def read_gro(stream):
+    """
+    Parse a gro file
+
+    Read an iterable over the lines of a GRO file. Returns the title, the
+    atoms, and the box. The atoms are returned as a list of dict, where each
+    dict represents an atom. The keys of the atom dicts are
+
+    * 'resid' for the residue number;
+    * 'resname' for the residue name;
+    * 'index' for the atom index as written in the file;
+    * 'name' for the atom name;
+    * 'x', 'y', and 'z' for the atom coordinates.
+
+    The box is returned as a list of floats.
+
+    .. note::
+
+       The function does not read velocities. Also, it does not support
+       variable precision.
+    """
+    # The two first lines are the header. The first line is the title of the
+    # structure, the second line is the number of atoms.
+    title = next(stream)
+    natoms = int(next(stream))
+
+    # Read the atoms according to the format described in GRO_FIELDS.
+    # We stop when we reached the number of atoms declared.
+    atoms = []
+    for atom_count, line in enumerate(stream, start=0):
+        if atom_count == natoms:
+            break
+        atoms.append({key: convert(line[begin:end].strip())
+                      for key, ((begin, end), convert) in GRO_FIELDS.items()})
+    else:
+        raise ValueError('Box missing or invalid number of atoms declared.')
+
+    # Read the box.
+    box = [float(x) for x in line.split()]
+
+    # Make sure there is nothing after the box.
+    try:
+        next(stream)
+    except StopIteration:
+        pass
+    else:
+        raise ValueError('Extra lines after the box or invalid number of atoms declared')
+
+    return title, atoms, box
+
+
+def compare_gro(stream, ref_stream, tolerance=0.001):
+    """
+    Compare two gro files with a tolerance on the coordinates
+
+    The `stream` and `ref_stream` arguments are iterable over the lines of two
+    GRO files to compare. The tolerance is provided in nanometer so that
+
+        abs(x1 - x2) <= tolerance
+
+    The function returns a list of differences. Each difference is represented
+    as a 'GroDiff' named tupple with the following field:
+
+    * 'linenum': the number of the line where the difference occurs, the line
+      count starts at 1 to make the difference easier to finc in a text editor;
+    * 'line' and 'ref_line': the line that differ as it is written in 'stream'
+      and in 'ref_stream', respectivelly;
+    * 'fields': the specific field that differ beween the lines.
+
+    The lines in the differences are re-formated from the information that have
+    been parsed. The exact string may differ, especially if velocities were
+    provided.
+
+    The fields in the difference list are named after the GRO_FIELDS dict. It
+    is `None` if the difference occurs in the title or the number of atoms. It
+    is 'box' if for the box.
+
+    If the number of atoms differ between the two files, then the atoms that
+    exist in only one of the files are all counted as different and the field
+    is set to `None`. If the box also differ, then its line number in the
+    repport will be wrong for one of the files.
+    """
+    differences = []
+    title, atoms, box = read_gro(stream)
+    title_ref, atoms_ref, box_ref = read_gro(ref_stream)
+
+    # Compare the headers
+    if title != title_ref:
+        diff = GroDiff(linenum=1, line=title, ref_line=title_ref, fields=None)
+        differences.append(diff)
+    if len(atoms) != len(atoms_ref):
+        diff = GroDiff(linenum=2,
+                       line=str(len(atoms)),
+                       ref_line=str(len(atoms_ref)),
+                       fields=None)
+        differences.append(diff)
+
+    # Compare the atoms
+    atom_iter = enumerate(
+        itertools.izip_longest(atoms, atoms_ref, fillvalue={}),
+        start=3
+    )
+    for linenum, (atom, atom_ref) in atom_iter:
+        if atom and atom_ref:
+            # Both the atom and the reference atoms are defined.
+            # We compare the fields.
+            diff_fields = []
+            for gro_field, (_, gro_type) in GRO_FIELDS.items():
+                if gro_type == float:
+                    # The field is a float, we compare with a tolerance.
+                    error = math.fabs(atom[gro_field] - atom_ref[gro_field])
+                    if error > tolerance:
+                        diff_fields.append(gro_field)
+                else:
+                    # The field is an int or a string, we check equality.
+                    if atom[gro_field] != atom_ref[gro_field]:
+                        diff_fields.append(gro_field)
+        else:
+            # At least one of the atoms is not defined. They are counted as
+            # different anyway, no need to compare anything.
+            diff_fields.append(None)
+        if diff_fields:
+            # We found a difference, add it to the list.
+            line = ref_line = ''
+            if atom:
+                line = GRO_TEMPLATE.format(**atom)
+            if atom_ref:
+                ref_line = GRO_TEMPLATE.format(**atom_ref)
+            diff = GroDiff(linenum=linenum,
+                           line=line,
+                           ref_line=ref_line,
+                           fields=diff_fields)
+            differences.append(diff)
+
+    # Compare the box
+    if box != box_ref:
+        diff = GroDiff(linenum=linenum + 1,
+                       line=' '.join(map(str, box)),
+                       ref_line=' '.join(map(str, box_ref)),
+                       fields='box')
+        differences.append(diff)
+
+    return differences
+
+
+def format_gro_diff(differences, outstream=sys.stdout, max_atoms=10):
+    """
+    Format differences between GRO files in a human readable way.
+    """
+    if not differences:
+        # Do not display anything if the two gro files are identical.
+        return
+
+    # We do not want to modify the input
+    differences = copy.copy(differences)
+
+    # Display the differences in metadata first
+    if differences and differences[0].linenum == 0:
+        diff = differences.pop(0)
+        print('The title is different:', file=outstream)
+        print(diff.line, file=outstream)
+        print(diff.ref_line, file=outstream)
+    if differences and differences[0].linenum == 1:
+        diff = differences.pop(0)
+        print('The number of atoms is different! '
+              '"{}" instead of "{}".'.format(diff.line, diff.ref_line),
+              file=outstream)
+    if differences and differences[-1].fields == 'box':
+        diff = differences.pop(-1)
+        print('The box is different:', file=outstream)
+        print(diff.line, file=outstream)
+        print(diff.ref_line, file=outstream)
+
+    # Then display the atoms. Only display 'max_atoms' ones.
+    if len(differences) > max_atoms:
+        print('There are {} atoms that differ. '
+              'Only displaying the {} first ones.'
+              .format(len(differences), max_atoms),
+              file=outstream)
+    for diff in differences[:max_atoms]:
+        print('On line {}:'.format(diff.linenum), file=outstream)
+        print(diff.line, file=outstream)
+        print(diff.ref_line, file=outstream)
+
+
+def assert_gro_equal(path, ref_path):
+    diff_out = StringIO()
+    with open(path) as stream, open(ref_path) as ref_stream:
+        differences = compare_gro(stream, ref_stream)
+        format_gro_diff(differences, outstream=diff_out)
+        assert len(differences) == 0, '\n' + diff_out.getvalue()
 
 
 def _gro_output_from_arguments(arguments):
@@ -289,7 +503,10 @@ def run_and_compare(arguments, input_dir, ref_gro, ref_stdout, ref_stderr):
         out, err, returncode = run_insane(arguments, input_dir)
         assert not returncode
         assert os.path.exists(gro_output)
-        compare(gro_output, ref_gro)
+        if os.path.splitext(gro_output)[-1] == '.gro':
+            assert_gro_equal(gro_output, ref_gro)
+        else:
+            compare(gro_output, ref_gro)
         compare(ContextStringIO(out), ref_stdout)
         compare(ContextStringIO(err), ref_stderr)
 
@@ -314,6 +531,151 @@ def test_simple_cases():
             ref_stderr=ref_stderr)
         _test_case.__doc__ = 'insane ' + case_args
         yield (_test_case, case_args, input_dir)
+
+
+class TestGroTester(object):
+    """
+    Test if the comparison of GRO file catches the differences.
+    """
+    ref_gro_content = """\
+    INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+    4
+        1POPC   NC3    1   2.111  14.647  11.951
+        1POPC   PO4    2   2.177  14.644  11.651
+        1POPC   GL1    3   2.128  14.642  11.351
+        1POPC   GL2    4   1.961  14.651  11.351
+    10 10 10"""
+
+    def test_equal(self):
+        """
+        Make sure that identical files do not fail.
+        """
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            assert_gro_equal('ref.gro', 'ref.gro')
+
+    def test_diff_x(self):
+        """
+        Make sure that error in coordinates is caught.
+        """
+        gro_content = """\
+        INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+        4
+            1POPC   NC3    1   2.111  14.647  11.951
+            1POPC   PO4    2   2.177  14.644  11.651
+            1POPC   GL1    3   2.128  14.642  11.353  # Is not within tolerance
+            1POPC   GL2    4   1.961  14.651  11.351
+        10 10 10"""
+
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            with open('content.gro', 'w') as outfile:
+                print(textwrap.dedent(gro_content), file=outfile, end='')
+            assert_raises(AssertionError, assert_gro_equal, 'content.gro', 'ref.gro')
+
+    def test_diff_in_tolerance(self):
+        """
+        Make sure that small errors in coordinates are not caught.
+        """
+        gro_content = """\
+        INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+        4
+            1POPC   NC3    1   2.111  14.647  11.951
+            1POPC   PO4    2   2.177  14.644  11.651
+            1POPC   GL1    3   2.128  14.642  11.352  # Is within tolerance
+            1POPC   GL2    4   1.961  14.651  11.351
+        10 10 10"""
+
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            with open('content.gro', 'w') as outfile:
+                print(textwrap.dedent(gro_content), file=outfile, end='')
+            assert_gro_equal('content.gro', 'ref.gro')
+
+    def test_diff_natoms(self):
+        """
+        Make sure that differences in number of atom is caught.
+        """
+        gro_content = """\
+        INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+        6
+            1POPC   NC3    1   2.111  14.647  11.951
+            1POPC   PO4    2   2.177  14.644  11.651
+            1POPC   GL1    3   2.128  14.642  11.351
+            1POPC   GL2    4   1.961  14.651  11.351
+            1POPC   C1A    5   2.125  14.651  11.051
+            1POPC   D2A    6   2.134  14.602  10.751
+        10 10 10"""
+
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            with open('content.gro', 'w') as outfile:
+                print(textwrap.dedent(gro_content), file=outfile, end='')
+            assert_raises(AssertionError, assert_gro_equal, 'content.gro', 'ref.gro')
+
+    def test_diff_title(self):
+        """
+        Make sure that a different title is caught.
+        """
+        gro_content = """\
+        A different title
+        4
+            1POPC   NC3    1   2.111  14.647  11.951
+            1POPC   PO4    2   2.177  14.644  11.651
+            1POPC   GL1    3   2.128  14.642  11.351
+            1POPC   GL2    4   1.961  14.651  11.351
+        10 10 10"""
+
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            with open('content.gro', 'w') as outfile:
+                print(textwrap.dedent(gro_content), file=outfile, end='')
+            assert_raises(AssertionError, assert_gro_equal, 'content.gro', 'ref.gro')
+
+    def test_diff_box(self):
+        """
+        Make sure that a different box is caught.
+        """
+        gro_content = """\
+        INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+        4
+            1POPC   NC3    1   2.111  14.647  11.951
+            1POPC   PO4    2   2.177  14.644  11.651
+            1POPC   GL1    3   2.128  14.642  11.351
+            1POPC   GL2    4   1.961  14.651  11.351
+        10 9.9 10 9.08 4 54"""
+
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            with open('content.gro', 'w') as outfile:
+                print(textwrap.dedent(gro_content), file=outfile, end='')
+            assert_raises(AssertionError, assert_gro_equal, 'content.gro', 'ref.gro')
+
+    def test_diff_field(self):
+        """
+        Make sure that a difference in a field is caught.
+        """
+        gro_content = """\
+        INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+        4
+            1POPC   NC3    1   2.111  14.647  11.951
+            1DIFF   PO4    2   2.177  14.644  11.651
+            1POPC   GL1    3   2.128  14.642  11.351
+            1POPC   GL2    4   1.961  14.651  11.351
+        10 10 10"""
+
+        with tempdir():
+            with open('ref.gro', 'w') as outfile:
+                print(textwrap.dedent(self.ref_gro_content), file=outfile, end='')
+            with open('content.gro', 'w') as outfile:
+                print(textwrap.dedent(gro_content), file=outfile, end='')
+            assert_raises(AssertionError, assert_gro_equal, 'content.gro', 'ref.gro')
 
 
 def generate_simple_case_references():


### PR DESCRIPTION
Comparing GRO files as text files means that small changes in rounding
force us to regenerate new files. This commit replaces the text-based
comparison of GRO files by a semantic one that reads the GRO file and
compare the content.

The commit also adds tests to make sure the tester works.

Note that PDB files are still compared as text files.