### PR TITLE
Absolute number of lipids kind of works

### DIFF
--- a/insane/cli.py
+++ b/insane/cli.py
@@ -21,7 +21,7 @@ import sys
 import simopt
 
 from . import core
-from .converters import vector, box3d
+from .converters import vector, box3d, molspec
 
 
 # Option list
@@ -59,8 +59,8 @@ OPTIONS = simopt.Options([
     meaning of the number depends on whether option -d is used to set up
     PBC
     """,
-        ("-l",    "lower",     str,         1,        None,  True, "Lipid type and relative abundance (NAME[:#])"),
-        ("-u",    "upper",     str,         1,        None,  True, "Lipid type and relative abundance (NAME[:#])"),
+        ("-l",    "lower",     molspec,     1,        None,  True, "Lipid type and relative abundance (NAME[:#])"),
+        ("-u",    "upper",     molspec,     1,        None,  True, "Lipid type and relative abundance (NAME[:#])"),
         ("-a",    "area",      float,       1,        0.60, False, "Area per lipid (nm*nm)"),
         ("-au",   "uparea",    float,       1,        None, False, "Area per lipid (nm*nm) for upper layer"),
         ("-asym", "asymmetry", int,         1,        None, False, "Membrane asymmetry (number of lipids)"),
@@ -82,7 +82,7 @@ OPTIONS = simopt.Options([
         """
     Solvent related options.
     """,
-        ("-sol",    "solvent",     str,         1,        None,  True, "Solvent type and relative abundance (NAME[:#])"),
+        ("-sol",    "solvent",     molspec,     1,        None,  True, "Solvent type and relative abundance (NAME[:#])"),
         ("-sold",   "soldiam",     float,       1,         0.5, False, "Solvent diameter"),
         ("-solr",   "solrandom",   float,       1,         0.1, False, "Solvent random kick"),
         ("-excl",   "solexcl",     float,       1,         1.5, False, "Exclusion range (nm) for solvent addition relative to membrane center"),

--- a/insane/cli.py
+++ b/insane/cli.py
@@ -64,7 +64,7 @@ OPTIONS = simopt.Options([
         ("-a",    "area",      float,       1,        0.60, False, "Area per lipid (nm*nm)"),
         ("-au",   "uparea",    float,       1,        None, False, "Area per lipid (nm*nm) for upper layer"),
         ("-asym", "asymmetry", int,         1,        None, False, "Membrane asymmetry (number of lipids)"),
-        ("-hole", "hole",      float,       1,        None, False, "Make a hole in the membrane with specified radius"),
+        ("-hole", "hole",      float,       1,           0, False, "Make a hole in the membrane with specified radius"),
         ("-disc", "disc",      float,       1,        None, False, "Make a membrane disc with specified radius"),
         ("-rand", "randkick",  float,       1,         0.1, False, "Random kick size (maximum atom displacement)"),
         ("-bd",   "beaddist",  float,       1,         0.3, False, "Bead distance unit for scaling z-coordinates (nm)"),

--- a/insane/converters.py
+++ b/insane/converters.py
@@ -46,3 +46,25 @@ def box3d(a):
         return x[0], x[0], x[0], 0, 0, 0, 0, 0, 0
     else:            # GRO format
         return x[0], x[3], x[4], x[5], x[1], x[6], x[7], x[8], x[2]
+
+
+def molspec(x):
+    """
+    Parse a string for a lipid or a solvent as given on the command line
+    (MOLECULE[=NUMBER|:NUMBER]); where `=NUMBER` sets an absolute number of the
+    molecule, and `:NUMBER` sets a relative number of it.
+    If both absolute and relative number are set False, then relative count is 1.
+    """
+    lip = x.split(":")
+    abn = lip[0].split("=")
+    names = abn[0]
+    if len(abn) > 1:
+        nrel = 0
+        nabs = int(abn[1])
+    else:
+        nabs = 0
+        if len(lip) > 1:
+            nrel = float(lip[1])
+        else:
+            nrel = 1
+    return abn[0], nabs, nrel

--- a/insane/core.py
+++ b/insane/core.py
@@ -221,6 +221,7 @@ class PBC(object):
             if v:
                 self.box[i,:] = v
 
+        self.box = self.box.astype(np.float64)
         return 
 
     @property
@@ -636,6 +637,7 @@ def old_main(argv, options):
         # box/d/x/y/z needed to define unit cell
 
         # box is set up already...
+        # yet it may be set to 0, then there is nothing we can do.
         if 0 in (pbc.x, pbc.y, pbc.z):
             raise PBCException('Not enough information to set the box size.')
     elif any(absL) or any(absU):
@@ -672,8 +674,11 @@ def old_main(argv, options):
         # to accomodate the fixed amount of lipids with given area.
         upscale = (upsize + unavail_up)/xysize
         loscale = (losize + unavail_lo)/xysize
-        scale = max(upscale, loscale)
-        pbc.box[:2,:] *= scale
+        area_scale = max(upscale, loscale)
+        aspect_ratio = pbc.x / pbc.y
+        scale_x = math.sqrt(area_scale / aspect_ratio)
+        scale_y = math.sqrt(area_scale / aspect_ratio)
+        pbc.box[:2,:] *= math.sqrt(area_scale)
         
 
     #<< PBC

--- a/insane/core.py
+++ b/insane/core.py
@@ -490,24 +490,6 @@ def ssd(u, v):
     return sum([(i-u[0])*(j-v[0]) for i, j in zip(u, v)])/(len(u)-1)
 
 
-# Parse a string for a lipid as given on the command line (LIPID[=NUMBER|:NUMBER])
-# If both absolute and relative number are set False, then relative count is 1
-def parse_mol(x):
-    lip = x.split(":")
-    abn = lip[0].split("=")
-    names = abn[0]
-    if len(abn) > 1:
-        nrel = 0
-        nabs = int(abn[1])
-    else:
-        nabs = 0
-        if len(lip) > 1:
-            nrel = float(lip[1])
-        else:
-            nrel = 1
-    return abn[0], nabs, nrel
-
-
 def old_main(argv, options):
 
     lipL      = options["lower"]
@@ -535,9 +517,9 @@ def old_main(argv, options):
     relU, relL, absU, absL = [], [], [], []
     if lipL:
         lipU = lipU or lipL
-        lipL, absL, relL = zip(*[ parse_mol(i) for i in lipL ])
+        lipL, absL, relL = zip(*lipL)
         totL       = float(sum(relL))
-        lipU, absU, relU = zip(*[ parse_mol(i) for i in lipU ])
+        lipU, absU, relU = zip(*lipU)
         totU       = float(sum(relU))
 
     lo_lipd  = math.sqrt(options["area"])
@@ -1047,7 +1029,7 @@ def old_main(argv, options):
         # (like when mixing a 1M solution of this with a 1M solution of that
 
         # First get names and relative numbers for each solvent
-        solnames, solabs, solnums = zip(*[ parse_mol(i) for i in solv ])
+        solnames, solabs, solnums = zip(*solv)
         solnames, solnums = list(solnames), list(solnums)
         totS       = float(sum(solnums))
 

--- a/insane/core.py
+++ b/insane/core.py
@@ -628,7 +628,6 @@ def old_main(argv, options):
               disc=options["disc"], hole=options["hole"], 
               membrane=options["lower"], protein=tm)
 
-    print(relL, relU, absL, absU, pbc.box)
     if any(relL) and any(relU):
         # Determine box from size
         # If one leaflet is defined with an absolute number of lipids
@@ -640,7 +639,6 @@ def old_main(argv, options):
         if 0 in (pbc.x, pbc.y, pbc.z):
             raise PBCException('Not enough information to set the box size.')
     elif any(absL) or any(absU):
-        print('This happens')
         # All numbers are absolute.. determine size from number of lipids
         # Box x/y will be set, d/dz/z is needed to set third box vector.
         # The area is needed to determine the size of the x/y plane OR
@@ -655,7 +653,6 @@ def old_main(argv, options):
             pbc.x = pbc.y = 1
         # A scaling factor is needed for the box
         # This is the area for the given number of lipids
-        print(sum(absU), options["uparea"])
         upsize = sum(absU) * options["uparea"]
         losize = sum(absL) * options["area"]
         # This is the size of the hole, going through both leaflets
@@ -914,12 +911,10 @@ def old_main(argv, options):
         # Types of lipids, relative numbers, fractions and numbers
 
         # Upper leaflet (+1)
-        print(upper, totU, relU)
         if totU:
             num_up     = [int(len(upper)*i/totU) for i in relU]
         else:
             num_up = absU
-        print('num_up', num_up)
         lip_up     = [l for i, l in zip(num_up, lipU) for j in range(i)]
         leaf_up    = ( 1, zip(lip_up, upper), up_lipd, up_lipdx, up_lipdy)
         molecules.extend(zip(lipU, num_up))


### PR DESCRIPTION
Setting an absolute number of lipids works to some extend.

* It will fail with protein until the protein area is implemented
* It does not work with discs

There are likely several other issues, but the basic example works: 

```bash
$ insane -o test.gro -l DPPC=500 -l CHOL=12 -z 10 -sol W -pbc square
; X: 17.527 (23 bins) Y: 17.527 (23 bins) in upper leaflet
; X: 17.527 (23 bins) Y: 17.527 (23 bins) in lower leaflet
; 529 lipids in upper leaflet, 529 lipids in lower leaflet
; NDX Solute 1 0
; Charge of protein: 0.000000
; NDX Membrane 1 12192
; Charge of membrane: 0.000000
; Total charge: 0.000000
; NDX Solvent 12193 25753
; NDX System 1 25753
; "I mean, the good stuff is just INSANE" --Julia Ormond
DPPC           500
CHOL            12
DPPC           500
CHOL            12
W            13561
$ tail test.gro 
14577W        W25745  11.481  14.856   7.889
14578W        W25746   4.643   9.532   8.367
14579W        W25747  15.828   2.216   0.265
14580W        W25748  13.405  13.878   8.372
14581W        W25749  11.488  13.877   1.225
14582W        W25750  14.402   0.739   8.364
14583W        W25751  12.428  13.406   7.886
14584W        W25752  12.913   0.266   9.323
14585W        W25753   6.617   2.696   9.315
  17.52712  17.52712  10.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
```