### PR TITLE
Even better tests

### DIFF
--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -box 2,3,4 -d 10.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -box 2,3,4 -d 10.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Insanely solvated protein.
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC             0
+POPC             0

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -box 20,30,40 -d 3.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -box 20,30,40 -d 3.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC           943
+POPC           941

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -box 20,30,40.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -box 20,30,40.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC           943
+POPC           941

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -center.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -center.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC             8
+POPC            11

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -dm 3.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -dm 3.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC             8
+POPC            37

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -orient -od 0.2.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -orient -od 0.2.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            15
+POPC            13

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -orient.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -orient.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            20
+POPC            31

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -ring.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -ring.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            12
+POPC            14

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -rotate 30.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -rotate 30.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            33
+POPC            33

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -rotate 40.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -rotate 40.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            38
+POPC            37

--- a/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -rotate princ.top
+++ b/tests/data/simple_case/-o test.gro -f CG1a0s.pdb -p CG1a0s.top -l POPC -rotate princ.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            37
+POPC            40

--- a/tests/data/simple_case/-o test.gro -pbc cubic -f CG1a0s.pdb -p CG1a0s.top.top
+++ b/tests/data/simple_case/-o test.gro -pbc cubic -f CG1a0s.pdb -p CG1a0s.top.top
@@ -1,0 +1,10 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Insanely solvated protein.
+
+
+[ molecules ]
+; name  number
+Protein          1

--- a/tests/data/simple_case/-o test.gro -pbc hexagonal -f CG1a0s.pdb -p CG1a0s.top.top
+++ b/tests/data/simple_case/-o test.gro -pbc hexagonal -f CG1a0s.pdb -p CG1a0s.top.top
@@ -1,0 +1,10 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Insanely solvated protein.
+
+
+[ molecules ]
+; name  number
+Protein          1

--- a/tests/data/simple_case/-o test.gro -pbc optimal -f CG1a0s.pdb -p CG1a0s.top.top
+++ b/tests/data/simple_case/-o test.gro -pbc optimal -f CG1a0s.pdb -p CG1a0s.top.top
@@ -1,0 +1,10 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Insanely solvated protein.
+
+
+[ molecules ]
+; name  number
+Protein          1

--- a/tests/data/simple_case/-o test.gro -pbc rectangular -f CG1a0s.pdb -p CG1a0s.top.top
+++ b/tests/data/simple_case/-o test.gro -pbc rectangular -f CG1a0s.pdb -p CG1a0s.top.top
@@ -1,0 +1,10 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Insanely solvated protein.
+
+
+[ molecules ]
+; name  number
+Protein          1

--- a/tests/data/simple_case/-o test.gro -pbc square -f CG1a0s.pdb -p CG1a0s.top.top
+++ b/tests/data/simple_case/-o test.gro -pbc square -f CG1a0s.pdb -p CG1a0s.top.top
@@ -1,0 +1,10 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Insanely solvated protein.
+
+
+[ molecules ]
+; name  number
+Protein          1

--- a/tests/data/simple_case/-o test.pdb -f CG1a0s.pdb -p CG1a0s.top -l POPC -ring.top
+++ b/tests/data/simple_case/-o test.pdb -f CG1a0s.pdb -p CG1a0s.top -l POPC -ring.top
@@ -1,0 +1,12 @@
+#include "martini.itp"
+
+[ system ]
+; name
+Protein in INSANE! Membrane UpperLeaflet>POPC=1 LowerLeaflet>POPC=1
+
+
+[ molecules ]
+; name  number
+Protein          1
+POPC            12
+POPC            14

--- a/tests/easy_copy.py
+++ b/tests/easy_copy.py
@@ -60,8 +60,14 @@ def replace_function(arguments, replace_files=True):
     """
     result = arguments
     input_dir = None
-    func_name = 'test_regression.test_simple_cases'
-    if arguments.startswith(func_name):
+    func_names = ('test_regression.test_simple_cases',
+                  'test_regression.test_simple_cases_internal')
+    func_name = None
+    for name in func_names:
+        if arguments.startswith(name + '('):
+            func_name = name
+            break
+    if func_name is not None:
         reduced_name = arguments[len(func_name) + 1:-1]
         insane_args, input_dir = shlex.split(reduced_name)
         if replace_files:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -35,14 +35,12 @@ and compares the output to the reference.
 
 from __future__ import print_function
 
-from collections import namedtuple
-import copy
 import contextlib
 import functools
 import glob
 import itertools
 import os
-import math
+import random
 import shutil
 import shlex
 import subprocess
@@ -53,51 +51,13 @@ import textwrap
 from StringIO import StringIO
 from nose.tools import assert_equal, assert_raises
 
-
-# realpath and which are copied from MDAnalysis.
-# MDAnalysis is released under the GPL v2 license.
-# Read the full license at
-# <https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE>
-def realpath(*args):
-    """Join all args and return the real path, rooted at /.
-    Expands '~', '~user', and environment variables such as :envvar`$HOME`.
-    Returns ``None`` if any of the args is ``None``.
-    """
-    if None in args:
-        return None
-    return os.path.realpath(
-        os.path.expanduser(os.path.expandvars(os.path.join(*args)))
-    )
-
-
-def which(program):
-    """Determine full path of executable *program* on :envvar:`PATH`.
-
-    (Jay at http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python)
-    """
-
-    def is_exe(fpath):
-        """
-        Returns True is the path points to an executable file.
-        """
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, _ = os.path.split(program)
-    if fpath:
-        real_program = realpath(program)
-        if is_exe(real_program):
-            return real_program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-    return None
+import insane.cli
+import utils
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 # INSANE = os.path.abspath(os.path.join(HERE, '../insane.py'))
-INSANE = which('insane')
+INSANE = utils.which('insane')
 DATA_DIR = os.path.join(HERE, 'data')
 INPUT_DIR = os.path.join(HERE, 'data', 'inputs')
 INSANE_SEED = '42'
@@ -159,70 +119,6 @@ for pbc in ('hexagonal', 'rectangular', 'square', 'cubic', 'optimal'):
         '-o test.gro -disc 8 -hole 4 -pbc {} -d 10'.format(pbc),
     ])
 
-# GRO file format description. The key is the name of the field, the value is a
-# tuple from which the first element is the first (included) and last
-# (excluded) indices of the field in the line, and the second element the type
-# of the field content.
-GRO_FIELDS = {
-    "resid": ((0, 5), int),
-    "resname": ((5, 10), str),
-    "name": ((10, 15), str),
-    "index": ((15, 20), int),
-    "x": ((20, 28), float),
-    "y": ((28, 36), float),
-    "z": ((36, 44), float),
-}
-GRO_TEMPLATE = ('{resid:>5}{resname:<5}{name:>5}{index:>5}'
-                '{x:8.3f}{y:8.3f}{z:8.3f}')
-
-GroDiff = namedtuple('GroDiff', 'linenum line ref_line fields')
-
-
-class ContextStringIO(StringIO):
-    """
-    StringIO but usable as a context manager.
-
-    StringIO can not completely pass as a file, because it is not usable as a
-    context manager in a 'with' statement. This class adds the context manager
-    hability to StringIO. It does nothing when the context manager is either
-    entered or exited, but it can be used in a 'with' statement.
-    """
-    def __enter__(self):
-        """
-        Does nothing when entering a 'with' statement.
-        """
-        pass
-
-    def __exit__(self, *args):
-        """
-        Does nothing when exiting a 'with' statement.
-        """
-        pass
-
-
-@contextlib.contextmanager
-def tempdir():
-    """
-    Context manager that moves in a temporary directory.
-
-    .. code::
-
-        # We are in the initial working directory
-        with tempdir():
-            # We are now in a temporary directory
-            ...
-        # We are back to the initial working directory.
-        # The temporary does not exist anymore.
-    """
-    return_dir = os.getcwd()
-    dirpath = tempfile.mkdtemp()
-    try:
-        os.chdir(dirpath)
-        yield dirpath
-    finally:
-        os.chdir(return_dir)
-        shutil.rmtree(dirpath)
-
 
 def _arguments_as_list(arguments):
     """
@@ -237,203 +133,6 @@ def _arguments_as_list(arguments):
     except ValueError:
         arguments_list = arguments
     return arguments_list
-
-
-def read_gro(stream):
-    """
-    Parse a gro file
-
-    Read an iterable over the lines of a GRO file. Returns the title, the
-    atoms, and the box. The atoms are returned as a list of dict, where each
-    dict represents an atom. The keys of the atom dicts are
-
-    * 'resid' for the residue number;
-    * 'resname' for the residue name;
-    * 'index' for the atom index as written in the file;
-    * 'name' for the atom name;
-    * 'x', 'y', and 'z' for the atom coordinates.
-
-    The box is returned as a list of floats.
-
-    .. note::
-
-       The function does not read velocities. Also, it does not support
-       variable precision.
-    """
-    # The two first lines are the header. The first line is the title of the
-    # structure, the second line is the number of atoms.
-    title = next(stream)
-    natoms = int(next(stream))
-
-    # Read the atoms according to the format described in GRO_FIELDS.
-    # We stop when we reached the number of atoms declared.
-    atoms = []
-    for atom_count, line in enumerate(stream, start=0):
-        if atom_count == natoms:
-            break
-        atoms.append({key: convert(line[begin:end].strip())
-                      for key, ((begin, end), convert) in GRO_FIELDS.items()})
-    else:
-        raise ValueError('Box missing or invalid number of atoms declared.')
-
-    # Read the box.
-    box = [float(x) for x in line.split()]
-
-    # Make sure there is nothing after the box.
-    try:
-        next(stream)
-    except StopIteration:
-        pass
-    else:
-        raise ValueError('Extra lines after the box or '
-                         'invalid number of atoms declared')
-
-    return title, atoms, box
-
-
-def compare_gro(stream, ref_stream, tolerance=0.001):
-    """
-    Compare two gro files with a tolerance on the coordinates
-
-    The `stream` and `ref_stream` arguments are iterable over the lines of two
-    GRO files to compare. The tolerance is provided in nanometer so that
-
-        abs(x1 - x2) <= tolerance
-
-    The function returns a list of differences. Each difference is represented
-    as a 'GroDiff' named tupple with the following field:
-
-    * 'linenum': the number of the line where the difference occurs, the line
-      count starts at 1 to make the difference easier to finc in a text editor;
-    * 'line' and 'ref_line': the line that differ as it is written in 'stream'
-      and in 'ref_stream', respectivelly;
-    * 'fields': the specific field that differ beween the lines.
-
-    The lines in the differences are re-formated from the information that have
-    been parsed. The exact string may differ, especially if velocities were
-    provided.
-
-    The fields in the difference list are named after the GRO_FIELDS dict. It
-    is `None` if the difference occurs in the title or the number of atoms. It
-    is 'box' if for the box.
-
-    If the number of atoms differ between the two files, then the atoms that
-    exist in only one of the files are all counted as different and the field
-    is set to `None`. If the box also differ, then its line number in the
-    repport will be wrong for one of the files.
-    """
-    differences = []
-    title, atoms, box = read_gro(stream)
-    title_ref, atoms_ref, box_ref = read_gro(ref_stream)
-
-    # Compare the headers
-    if title != title_ref:
-        diff = GroDiff(linenum=1, line=title, ref_line=title_ref, fields=None)
-        differences.append(diff)
-    if len(atoms) != len(atoms_ref):
-        diff = GroDiff(linenum=2,
-                       line=str(len(atoms)),
-                       ref_line=str(len(atoms_ref)),
-                       fields=None)
-        differences.append(diff)
-
-    # Compare the atoms
-    atom_iter = enumerate(
-        itertools.izip_longest(atoms, atoms_ref, fillvalue={}),
-        start=3
-    )
-    for linenum, (atom, atom_ref) in atom_iter:
-        if atom and atom_ref:
-            # Both the atom and the reference atoms are defined.
-            # We compare the fields.
-            diff_fields = []
-            for gro_field, (_, gro_type) in GRO_FIELDS.items():
-                if gro_type == float:
-                    # The field is a float, we compare with a tolerance.
-                    error = math.fabs(atom[gro_field] - atom_ref[gro_field])
-                    if error > tolerance:
-                        diff_fields.append(gro_field)
-                else:
-                    # The field is an int or a string, we check equality.
-                    if atom[gro_field] != atom_ref[gro_field]:
-                        diff_fields.append(gro_field)
-        else:
-            # At least one of the atoms is not defined. They are counted as
-            # different anyway, no need to compare anything.
-            diff_fields.append(None)
-        if diff_fields:
-            # We found a difference, add it to the list.
-            line = ref_line = ''
-            if atom:
-                line = GRO_TEMPLATE.format(**atom)
-            if atom_ref:
-                ref_line = GRO_TEMPLATE.format(**atom_ref)
-            diff = GroDiff(linenum=linenum,
-                           line=line,
-                           ref_line=ref_line,
-                           fields=diff_fields)
-            differences.append(diff)
-
-    # Compare the box
-    if box != box_ref:
-        diff = GroDiff(linenum=linenum + 1,
-                       line=' '.join(map(str, box)),
-                       ref_line=' '.join(map(str, box_ref)),
-                       fields='box')
-        differences.append(diff)
-
-    return differences
-
-
-def format_gro_diff(differences, outstream=sys.stdout, max_atoms=10):
-    """
-    Format differences between GRO files in a human readable way.
-    """
-    if not differences:
-        # Do not display anything if the two gro files are identical.
-        return
-
-    # We do not want to modify the input
-    differences = copy.copy(differences)
-
-    # Display the differences in metadata first
-    if differences and differences[0].linenum == 0:
-        diff = differences.pop(0)
-        print('The title is different:', file=outstream)
-        print(diff.line, file=outstream)
-        print(diff.ref_line, file=outstream)
-    if differences and differences[0].linenum == 1:
-        diff = differences.pop(0)
-        print('The number of atoms is different! '
-              '"{}" instead of "{}".'.format(diff.line, diff.ref_line),
-              file=outstream)
-    if differences and differences[-1].fields == 'box':
-        diff = differences.pop(-1)
-        print('The box is different:', file=outstream)
-        print(diff.line, file=outstream)
-        print(diff.ref_line, file=outstream)
-
-    # Then display the atoms. Only display 'max_atoms' ones.
-    if len(differences) > max_atoms:
-        print('There are {} atoms that differ. '
-              'Only displaying the {} first ones.'
-              .format(len(differences), max_atoms),
-              file=outstream)
-    for diff in differences[:max_atoms]:
-        print('On line {}:'.format(diff.linenum), file=outstream)
-        print(diff.line, file=outstream)
-        print(diff.ref_line, file=outstream)
-
-
-def assert_gro_equal(path, ref_path):
-    """
-    Raise an AssertionError if two GRO files are not semantically identical.
-    """
-    diff_out = StringIO()
-    with open(path) as stream, open(ref_path) as ref_stream:
-        differences = compare_gro(stream, ref_stream)
-        format_gro_diff(differences, outstream=diff_out)
-        assert len(differences) == 0, '\n' + diff_out.getvalue()
 
 
 def _gro_output_from_arguments(arguments):
@@ -452,15 +151,6 @@ def _gro_output_from_arguments(arguments):
         raise ValueError('Output GRO name is not provided to insane. '
                          'Missing -o argument.')
     return arguments[i + 1]
-
-
-def _open_if_needed(handle):
-    """
-    Return handle if it is a ContextStringIO instance else try to open it.
-    """
-    if isinstance(handle, ContextStringIO):
-        return handle
-    return open(handle)
 
 
 def _split_case(case):
@@ -496,7 +186,30 @@ def _reference_path(arguments, alias=None):
     return ref_gro, ref_stdout, ref_stderr
 
 
-def run_insane(arguments, input_directory=None):
+def _run_external(arguments):
+    command = [INSANE] + arguments
+    process = subprocess.Popen(command,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               env={'INSANE_SEED': INSANE_SEED})
+    out, err = process.communicate()
+    return out, err, process.returncode
+
+
+def _run_internal(arguments):
+    os.environ['INSANE_SEED'] = INSANE_SEED
+    random.seed(INSANE_SEED)
+    command = [INSANE] + arguments
+    out = StringIO()
+    err = StringIO()
+    with utils._redirect_out_and_err(out, err):
+        returncode = insane.cli.main(command)
+    out = out.getvalue()
+    err = err.getvalue()
+    return out, err, returncode
+
+
+def run_insane(arguments, input_directory=None, runner=_run_external):
     """
     Run insane with the given arguments
 
@@ -510,24 +223,19 @@ def run_insane(arguments, input_directory=None):
                 shutil.copytree(path, '.')
             else:
                 shutil.copy2(path, '.')
-    command = [INSANE] + arguments
-    process = subprocess.Popen(command,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE,
-                               env={'INSANE_SEED': INSANE_SEED})
-    out, err = process.communicate()
-    print("** Insane exited with return code {}.".format(process.returncode))
-    if process.returncode:
+    out, err, returncode = runner(arguments)
+    print("** Insane exited with return code {}.".format(returncode))
+    if returncode:
         print(err)
-    return out, err, process.returncode
+    return out, err, returncode
 
 
 def compare(output, reference):
     """
     Assert that two files are identical.
     """
-    out_file = _open_if_needed(output)
-    ref_file = _open_if_needed(reference)
+    out_file = utils._open_if_needed(output)
+    ref_file = utils._open_if_needed(reference)
     with out_file, ref_file:
         lines_zip = itertools.izip_longest(out_file, ref_file, fillvalue=None)
         for out_line, ref_line in lines_zip:
@@ -538,7 +246,8 @@ def compare(output, reference):
         assert_equal(extra_ref, [])
 
 
-def run_and_compare(arguments, input_dir, ref_gro, ref_stdout, ref_stderr):
+def run_and_compare(arguments, input_dir,
+                    ref_gro, ref_stdout, ref_stderr, runner=_run_external):
     """
     Run insane and compare its output against a reference
     """
@@ -555,19 +264,19 @@ def run_and_compare(arguments, input_dir, ref_gro, ref_stdout, ref_stderr):
 
     # We want insane to run in a temporary directory. This allows to keep the
     # file system clean, and it avoids mixing output of different tests.
-    with tempdir():
-        out, err, returncode = run_insane(arguments, input_dir)
+    with utils.tempdir():
+        out, err, returncode = run_insane(arguments, input_dir, runner=runner)
         assert not returncode
         assert os.path.exists(gro_output)
         if os.path.splitext(gro_output)[-1] == '.gro':
-            assert_gro_equal(gro_output, ref_gro)
+            utils.assert_gro_equal(gro_output, ref_gro)
         else:
             compare(gro_output, ref_gro)
-        compare(ContextStringIO(out), ref_stdout)
-        compare(ContextStringIO(err), ref_stderr)
+        compare(utils.ContextStringIO(out), ref_stdout)
+        compare(utils.ContextStringIO(err), ref_stderr)
 
 
-def test_simple_cases():
+def _test_simple_cases():
     """
     This function generates test functions for nosetests. These test functions
     execute insane with the argument listed in SIMPLE_TEST_CASES.
@@ -583,10 +292,32 @@ def test_simple_cases():
             run_and_compare,
             ref_gro=ref_gro,
             ref_stdout=ref_stdout,
-            ref_stderr=ref_stderr)
+            ref_stderr=ref_stderr,
+            runner=_run_external)
         _test_case.__doc__ = 'insane ' + case_args
         yield (_test_case, case_args, input_dir)
 
+
+def test_simple_cases_internal():
+    """
+    This function generates test functions for nosetests. These test functions
+    calls insane's main function with the argument listed in SIMPLE_TEST_CASES.
+    """
+    for case in SIMPLE_TEST_CASES:
+        case_args, input_dir, alias = _split_case(case)
+        ref_gro, ref_stdout, ref_stderr = _reference_path(case_args, alias)
+        # The test generator could yield run and compare directly. Bt, then,
+        # the verbose display of nosetests gets crowded with the very long
+        # names of the reference file, that are very redundant. Using a partial
+        # function allows to have only the arguments for insane displayed.
+        _test_case = functools.partial(
+            run_and_compare,
+            ref_gro=ref_gro,
+            ref_stdout=ref_stdout,
+            ref_stderr=ref_stderr,
+            runner=_run_internal)
+        _test_case.__doc__ = 'insane ' + case_args
+        yield (_test_case, case_args, input_dir)
 
 class TestGroTester(object):
     """
@@ -605,11 +336,11 @@ class TestGroTester(object):
         """
         Make sure that identical files do not fail.
         """
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
-            assert_gro_equal('ref.gro', 'ref.gro')
+            utils.assert_gro_equal('ref.gro', 'ref.gro')
 
     def test_diff_x(self):
         """
@@ -624,13 +355,13 @@ class TestGroTester(object):
             1POPC   GL2    4   1.961  14.651  11.351
         10 10 10"""
 
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
             with open('content.gro', 'w') as outfile:
                 print(textwrap.dedent(gro_content), file=outfile, end='')
-            assert_raises(AssertionError, assert_gro_equal,
+            assert_raises(AssertionError, utils.assert_gro_equal,
                           'content.gro', 'ref.gro')
 
     def test_diff_in_tolerance(self):
@@ -646,13 +377,13 @@ class TestGroTester(object):
             1POPC   GL2    4   1.961  14.651  11.351
         10 10 10"""
 
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
             with open('content.gro', 'w') as outfile:
                 print(textwrap.dedent(gro_content), file=outfile, end='')
-            assert_gro_equal('content.gro', 'ref.gro')
+            utils.assert_gro_equal('content.gro', 'ref.gro')
 
     def test_diff_natoms(self):
         """
@@ -669,13 +400,13 @@ class TestGroTester(object):
             1POPC   D2A    6   2.134  14.602  10.751
         10 10 10"""
 
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
             with open('content.gro', 'w') as outfile:
                 print(textwrap.dedent(gro_content), file=outfile, end='')
-            assert_raises(AssertionError, assert_gro_equal,
+            assert_raises(AssertionError, utils.assert_gro_equal,
                           'content.gro', 'ref.gro')
 
     def test_diff_title(self):
@@ -691,13 +422,13 @@ class TestGroTester(object):
             1POPC   GL2    4   1.961  14.651  11.351
         10 10 10"""
 
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
             with open('content.gro', 'w') as outfile:
                 print(textwrap.dedent(gro_content), file=outfile, end='')
-            assert_raises(AssertionError, assert_gro_equal,
+            assert_raises(AssertionError, utils.assert_gro_equal,
                           'content.gro', 'ref.gro')
 
     def test_diff_box(self):
@@ -713,13 +444,13 @@ class TestGroTester(object):
             1POPC   GL2    4   1.961  14.651  11.351
         10 9.9 10 9.08 4 54"""
 
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
             with open('content.gro', 'w') as outfile:
                 print(textwrap.dedent(gro_content), file=outfile, end='')
-            assert_raises(AssertionError, assert_gro_equal,
+            assert_raises(AssertionError, utils.assert_gro_equal,
                           'content.gro', 'ref.gro')
 
     def test_diff_field(self):
@@ -735,13 +466,13 @@ class TestGroTester(object):
             1POPC   GL2    4   1.961  14.651  11.351
         10 10 10"""
 
-        with tempdir():
+        with utils.tempdir():
             with open('ref.gro', 'w') as outfile:
                 print(textwrap.dedent(self.ref_gro_content),
                       file=outfile, end='')
             with open('content.gro', 'w') as outfile:
                 print(textwrap.dedent(gro_content), file=outfile, end='')
-            assert_raises(AssertionError, assert_gro_equal,
+            assert_raises(AssertionError, utils.assert_gro_equal,
                           'content.gro', 'ref.gro')
 
 
@@ -758,7 +489,7 @@ def generate_simple_case_references():
         arguments = _arguments_as_list(case_args)
         out_gro = _gro_output_from_arguments(arguments)
         ref_gro, ref_stdout, ref_stderr = _reference_path(case_args, alias)
-        with tempdir():
+        with utils.tempdir():
             print(INSANE + ' ' + ' '.join(arguments))
             out, err, _ = run_insane(arguments, input_dir)
             with open(ref_stdout, 'w') as outfile:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+# INSert membrANE
+# A simple, versatile tool for building coarse-grained simulation systems
+# Copyright (C) 2017  Tsjerk A. Wassenaar and contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+from __future__ import print_function
+
+import copy
+from collections import namedtuple
+import contextlib
+import itertools
+import math
+import os
+import shutil
+from StringIO import StringIO
+import sys
+import tempfile
+
+# GRO file format description. The key is the name of the field, the value is a
+# tuple from which the first element is the first (included) and last
+# (excluded) indices of the field in the line, and the second element the type
+# of the field content.
+GRO_FIELDS = {
+    "resid": ((0, 5), int),
+    "resname": ((5, 10), str),
+    "name": ((10, 15), str),
+    "index": ((15, 20), int),
+    "x": ((20, 28), float),
+    "y": ((28, 36), float),
+    "z": ((36, 44), float),
+}
+GRO_TEMPLATE = ('{resid:>5}{resname:<5}{name:>5}{index:>5}'
+                '{x:8.3f}{y:8.3f}{z:8.3f}')
+
+GroDiff = namedtuple('GroDiff', 'linenum line ref_line fields')
+
+
+class ContextStringIO(StringIO):
+    """
+    StringIO but usable as a context manager.
+
+    StringIO can not completely pass as a file, because it is not usable as a
+    context manager in a 'with' statement. This class adds the context manager
+    hability to StringIO. It does nothing when the context manager is either
+    entered or exited, but it can be used in a 'with' statement.
+    """
+    def __enter__(self):
+        """
+        Does nothing when entering a 'with' statement.
+        """
+        pass
+
+    def __exit__(self, *args):
+        """
+        Does nothing when exiting a 'with' statement.
+        """
+        pass
+
+
+@contextlib.contextmanager
+def tempdir():
+    """
+    Context manager that moves in a temporary directory.
+
+    .. code::
+
+        # We are in the initial working directory
+        with tempdir():
+            # We are now in a temporary directory
+            ...
+        # We are back to the initial working directory.
+        # The temporary does not exist anymore.
+    """
+    return_dir = os.getcwd()
+    dirpath = tempfile.mkdtemp()
+    try:
+        os.chdir(dirpath)
+        yield dirpath
+    finally:
+        os.chdir(return_dir)
+        shutil.rmtree(dirpath)
+
+
+# realpath and which are copied from MDAnalysis.
+# MDAnalysis is released under the GPL v2 license.
+# Read the full license at
+# <https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE>
+def realpath(*args):
+    """Join all args and return the real path, rooted at /.
+    Expands '~', '~user', and environment variables such as :envvar`$HOME`.
+    Returns ``None`` if any of the args is ``None``.
+    """
+    if None in args:
+        return None
+    return os.path.realpath(
+        os.path.expanduser(os.path.expandvars(os.path.join(*args)))
+    )
+
+
+def which(program):
+    """Determine full path of executable *program* on :envvar:`PATH`.
+
+    (Jay at http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python)
+    """
+
+    def is_exe(fpath):
+        """
+        Returns True is the path points to an executable file.
+        """
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, _ = os.path.split(program)
+    if fpath:
+        real_program = realpath(program)
+        if is_exe(real_program):
+            return real_program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+    return None
+
+
+def read_gro(stream):
+    """
+    Parse a gro file
+
+    Read an iterable over the lines of a GRO file. Returns the title, the
+    atoms, and the box. The atoms are returned as a list of dict, where each
+    dict represents an atom. The keys of the atom dicts are
+
+    * 'resid' for the residue number;
+    * 'resname' for the residue name;
+    * 'index' for the atom index as written in the file;
+    * 'name' for the atom name;
+    * 'x', 'y', and 'z' for the atom coordinates.
+
+    The box is returned as a list of floats.
+
+    .. note::
+
+       The function does not read velocities. Also, it does not support
+       variable precision.
+    """
+    # The two first lines are the header. The first line is the title of the
+    # structure, the second line is the number of atoms.
+    title = next(stream)
+    natoms = int(next(stream))
+
+    # Read the atoms according to the format described in GRO_FIELDS.
+    # We stop when we reached the number of atoms declared.
+    atoms = []
+    for atom_count, line in enumerate(stream, start=0):
+        if atom_count == natoms:
+            break
+        atoms.append({key: convert(line[begin:end].strip())
+                      for key, ((begin, end), convert) in GRO_FIELDS.items()})
+    else:
+        raise ValueError('Box missing or invalid number of atoms declared.')
+
+    # Read the box.
+    box = [float(x) for x in line.split()]
+
+    # Make sure there is nothing after the box.
+    try:
+        next(stream)
+    except StopIteration:
+        pass
+    else:
+        raise ValueError('Extra lines after the box or '
+                         'invalid number of atoms declared')
+
+    return title, atoms, box
+
+
+def compare_gro(stream, ref_stream, tolerance=0.001):
+    """
+    Compare two gro files with a tolerance on the coordinates
+
+    The `stream` and `ref_stream` arguments are iterable over the lines of two
+    GRO files to compare. The tolerance is provided in nanometer so that
+
+        abs(x1 - x2) <= tolerance
+
+    The function returns a list of differences. Each difference is represented
+    as a 'GroDiff' named tupple with the following field:
+
+    * 'linenum': the number of the line where the difference occurs, the line
+      count starts at 1 to make the difference easier to finc in a text editor;
+    * 'line' and 'ref_line': the line that differ as it is written in 'stream'
+      and in 'ref_stream', respectivelly;
+    * 'fields': the specific field that differ beween the lines.
+
+    The lines in the differences are re-formated from the information that have
+    been parsed. The exact string may differ, especially if velocities were
+    provided.
+
+    The fields in the difference list are named after the GRO_FIELDS dict. It
+    is `None` if the difference occurs in the title or the number of atoms. It
+    is 'box' if for the box.
+
+    If the number of atoms differ between the two files, then the atoms that
+    exist in only one of the files are all counted as different and the field
+    is set to `None`. If the box also differ, then its line number in the
+    repport will be wrong for one of the files.
+    """
+    differences = []
+    title, atoms, box = read_gro(stream)
+    title_ref, atoms_ref, box_ref = read_gro(ref_stream)
+
+    # Compare the headers
+    if title != title_ref:
+        diff = GroDiff(linenum=1, line=title, ref_line=title_ref, fields=None)
+        differences.append(diff)
+    if len(atoms) != len(atoms_ref):
+        diff = GroDiff(linenum=2,
+                       line=str(len(atoms)),
+                       ref_line=str(len(atoms_ref)),
+                       fields=None)
+        differences.append(diff)
+
+    # Compare the atoms
+    atom_iter = enumerate(
+        itertools.izip_longest(atoms, atoms_ref, fillvalue={}),
+        start=3
+    )
+    for linenum, (atom, atom_ref) in atom_iter:
+        if atom and atom_ref:
+            # Both the atom and the reference atoms are defined.
+            # We compare the fields.
+            diff_fields = []
+            for gro_field, (_, gro_type) in GRO_FIELDS.items():
+                if gro_type == float:
+                    # The field is a float, we compare with a tolerance.
+                    error = math.fabs(atom[gro_field] - atom_ref[gro_field])
+                    if error > tolerance:
+                        diff_fields.append(gro_field)
+                else:
+                    # The field is an int or a string, we check equality.
+                    if atom[gro_field] != atom_ref[gro_field]:
+                        diff_fields.append(gro_field)
+        else:
+            # At least one of the atoms is not defined. They are counted as
+            # different anyway, no need to compare anything.
+            diff_fields.append(None)
+        if diff_fields:
+            # We found a difference, add it to the list.
+            line = ref_line = ''
+            if atom:
+                line = GRO_TEMPLATE.format(**atom)
+            if atom_ref:
+                ref_line = GRO_TEMPLATE.format(**atom_ref)
+            diff = GroDiff(linenum=linenum,
+                           line=line,
+                           ref_line=ref_line,
+                           fields=diff_fields)
+            differences.append(diff)
+
+    # Compare the box
+    if box != box_ref:
+        diff = GroDiff(linenum=linenum + 1,
+                       line=' '.join(map(str, box)),
+                       ref_line=' '.join(map(str, box_ref)),
+                       fields='box')
+        differences.append(diff)
+
+    return differences
+
+
+def format_gro_diff(differences, outstream=sys.stdout, max_atoms=10):
+    """
+    Format differences between GRO files in a human readable way.
+    """
+    if not differences:
+        # Do not display anything if the two gro files are identical.
+        return
+
+    # We do not want to modify the input
+    differences = copy.copy(differences)
+
+    # Display the differences in metadata first
+    if differences and differences[0].linenum == 0:
+        diff = differences.pop(0)
+        print('The title is different:', file=outstream)
+        print(diff.line, file=outstream)
+        print(diff.ref_line, file=outstream)
+    if differences and differences[0].linenum == 1:
+        diff = differences.pop(0)
+        print('The number of atoms is different! '
+              '"{}" instead of "{}".'.format(diff.line, diff.ref_line),
+              file=outstream)
+    if differences and differences[-1].fields == 'box':
+        diff = differences.pop(-1)
+        print('The box is different:', file=outstream)
+        print(diff.line, file=outstream)
+        print(diff.ref_line, file=outstream)
+
+    # Then display the atoms. Only display 'max_atoms' ones.
+    if len(differences) > max_atoms:
+        print('There are {} atoms that differ. '
+              'Only displaying the {} first ones.'
+              .format(len(differences), max_atoms),
+              file=outstream)
+    for diff in differences[:max_atoms]:
+        print('On line {}:'.format(diff.linenum), file=outstream)
+        print(diff.line, file=outstream)
+        print(diff.ref_line, file=outstream)
+
+
+def assert_gro_equal(path, ref_path):
+    """
+    Raise an AssertionError if two GRO files are not semantically identical.
+    """
+    diff_out = StringIO()
+    with open(path) as stream, open(ref_path) as ref_stream:
+        differences = compare_gro(stream, ref_stream)
+        format_gro_diff(differences, outstream=diff_out)
+        assert len(differences) == 0, '\n' + diff_out.getvalue()
+
+def _open_if_needed(handle):
+    """
+    Return handle if it is a ContextStringIO instance else try to open it.
+    """
+    if isinstance(handle, ContextStringIO):
+        return handle
+    return open(handle)
+
+
+@contextlib.contextmanager
+def _redirect_out_and_err(stdout, stderr):
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    try:
+        sys.stdout = stdout
+        sys.stderr = stderr
+        yield
+    finally:
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr


### PR DESCRIPTION
The regression tests call `insane.cli.main` function rather than the
insane program. This makes tests faster, and it makes reporting test
coverage possible.

The old way is still there but is not discoverable by nose. I need to
find a way to make it possible to toggle between running the insane
program or the insane's main function. I may also just strip the old way
completely. The new method offers more flexibility but does not test the
actual entry point created by pip.

In addition, the top files are now compared to the reference when relevant.

Finally, accessory functions move in `test/utils.py`.

