### PR TITLE
Python call

### DIFF
--- a/insane/cli.py
+++ b/insane/cli.py
@@ -136,6 +136,7 @@ def main(argv):
     # Build index
 
 
+
     (molecules,
      protein,
      membrane,
@@ -143,19 +144,18 @@ def main(argv):
      lipU, lipL,
      numU, numL,
      box) = core.old_main(**options)
-    core.write_all(
+
+    title = core.system_title(membrane, protein, lipU, lipL, numU, numL)
+    atoms = protein + membrane + solvent
+
+    core.write_summary(protein, membrane, solvent)
+    core.write_structure(
         output=options['output'],
-        topology=options['topology'],
-        molecules=molecules,
-        protein=protein,
-        membrane=membrane,
-        solvent=solvent,
-        lipU=lipU,
-        lipL=lipL,
-        numU=numU,
-        numL=numL,
+        title=title,
+        atoms=atoms,
         box=box,
     )
+    core.write_top(options['topology'], molecules, title)
 
     return 0
 

--- a/insane/cli.py
+++ b/insane/cli.py
@@ -142,7 +142,7 @@ def main(argv):
      solvent,
      lipU, lipL,
      numU, numL,
-     box) = core.old_main(argv, options)
+     box) = core.old_main(**options)
     core.write_all(
         output=options['output'],
         topology=options['topology'],

--- a/insane/cli.py
+++ b/insane/cli.py
@@ -141,11 +141,10 @@ def main(argv):
      protein,
      membrane,
      solvent,
-     lipU, lipL,
-     numU, numL,
+     lipids,
      box) = core.old_main(**options)
 
-    title = core.system_title(membrane, protein, lipU, lipL, numU, numL)
+    title = core.system_title(membrane, protein, lipids)
     atoms = protein + membrane + solvent
 
     core.write_summary(protein, membrane, solvent)

--- a/insane/core.py
+++ b/insane/core.py
@@ -1335,10 +1335,7 @@ def write_top(outpath, molecules, title):
         print("\n".join("%-10s %7d"%i for i in added_molecules), file=sys.stderr)
 
 
-def write_all(output, topology, molecules, protein, membrane, solvent,
-              lipU, lipL, numU, numL, box):
-    write_summary(protein, membrane, solvent)
-
+def system_title(membrane, protein, lipU, lipL, numU, numL):
     if membrane.atoms:
         title  = "INSANE! Membrane UpperLeaflet>"+":".join(lipU)+"="+":".join([str(i) for i in numU])
         title += " LowerLeaflet>"+":".join(lipL)+"="+":".join([str(i) for i in numL])
@@ -1347,17 +1344,16 @@ def write_all(output, topology, molecules, protein, membrane, solvent,
             title = "Protein in " + title
     else:
         title = "Insanely solvated protein."
+    return title
 
-    atoms = protein + membrane + solvent
 
+def write_structure(output, title, atoms, box):
     oStream = output and open(output, "w") or sys.stdout
     with oStream:
         if output.endswith(".gro"):
             write_gro(oStream, title, atoms, box.tolist())
         else:
             write_pdb(oStream, title, atoms, box.tolist())
-
-    write_top(topology, molecules, title)
 
 
 def insane(**options):

--- a/insane/core.py
+++ b/insane/core.py
@@ -1044,7 +1044,7 @@ def setup_membrane(pbc, protein, lipid, options):
     return membrane, molecules
 
 
-def old_main(argv, options):
+def old_main(**options):
 
     molecules = []
 

--- a/insane/core.py
+++ b/insane/core.py
@@ -1199,8 +1199,7 @@ def old_main(**options):
     solvent, added = setup_solvent(pbc, protein, membrane, options)
     molecules.extend(added)
 
-    return (molecules, protein, membrane, solvent,
-            lipU, lipL, relU, relL, pbc.box)
+    return (molecules, protein, membrane, solvent, lipid, pbc.box)
 
 
 
@@ -1335,10 +1334,11 @@ def write_top(outpath, molecules, title):
         print("\n".join("%-10s %7d"%i for i in added_molecules), file=sys.stderr)
 
 
-def system_title(membrane, protein, lipU, lipL, numU, numL):
+def system_title(membrane, protein, lipids):
+    (lipL, absL, relL), (lipU, absU, relU) = lipids
     if membrane.atoms:
-        title  = "INSANE! Membrane UpperLeaflet>"+":".join(lipU)+"="+":".join([str(i) for i in numU])
-        title += " LowerLeaflet>"+":".join(lipL)+"="+":".join([str(i) for i in numL])
+        title  = "INSANE! Membrane UpperLeaflet>"+":".join(lipU)+"="+":".join([str(i) for i in relU])
+        title += " LowerLeaflet>"+":".join(lipL)+"="+":".join([str(i) for i in relL])
 
         if protein:
             title = "Protein in " + title


### PR DESCRIPTION
Streamline the signature and the return values of `insane.old_main`

This allows to do things like:

```python
import insane
import insane.cli

options = insane.cli.OPTIONS._default_dict()
options['out'] = 'memb.gro'
options['distance'] = 10
options['upper'] = [('DOPC', 0, 1)]

insane.old_main(options)
```

It also decouples the writing methods to be used from a python interpretor.