### PR TITLE
Fix absolute

### DIFF
--- a/insane/core.py
+++ b/insane/core.py
@@ -800,8 +800,6 @@ def setup_membrane(pbc, protein, lipid, options):
     lo_lipd = np.sqrt(options["area"])
     up_lipd = np.sqrt(options["uparea"])
 
-    print('lipd', lo_lipd, up_lipd)
-
     num_up, num_lo = [], []
 
     # Lipids are added on grid positions, using the prototypes defined above.
@@ -869,8 +867,6 @@ def setup_membrane(pbc, protein, lipid, options):
 
     #print(absU, sum(~occupied_up.astype('bool')), 
     #      absL, sum(~occupied_lo.astype('bool')))
-    print('->', len(grid_lo), len(grid_lo[0]))
-    print('->', len(grid_up), len(grid_up[0]))
 
 
     ## OLD GRID
@@ -1168,11 +1164,9 @@ def old_main(**options):
     if options["uparea"] is None:
         options["uparea"] = options["area"]
 
-    print(pbc.box)
     resize_pbc_for_lipids(pbc=pbc, relL=relL, relU=relU, absL=absL, absU=absU,
                           uparea=options["uparea"], area=options["area"],
                           hole=options["hole"], proteins=tm)
-    print(pbc.box)
 
     ##################
     ## IV. MEMBRANE ##

--- a/tests/test_absolute.py
+++ b/tests/test_absolute.py
@@ -22,17 +22,20 @@
 Test that a user can ask for an absolute number of lipids.
 """
 
+import sys
 from nose.tools import assert_equal, assert_raises
+import utils
 import insane
 
 def test_absolute_lipid_only():
-    (molecules,
-     protein,
-     membrane,
-     solvent,
-     lipids,
-     box) = insane.core.old_main(lower=[('DOPC', 72, 0)],
-                                 output='plop.gro', zdistance=15)
+    with utils._redirect_out_and_err(sys.stdout, sys.stdout):
+        (molecules,
+         protein,
+         membrane,
+         solvent,
+         lipids,
+         box) = insane.core.old_main(lower=[('DOPC', 72, 0)],
+                                     output='plop.gro', zdistance=15)
     npo4 = len([atom for atom in membrane.atoms if atom[0] == 'PO4'])
     assert_equal(npo4, 72 * 2)
     assert_equal(molecules, [('DOPC', 72), ('DOPC', 72)])
@@ -42,17 +45,37 @@ def test_absolute_lipid_only():
 
 
 def test_absolute_lipid_assym():
-    (molecules,
-     protein,
-     membrane,
-     solvent,
-     lipids,
-     box) = insane.core.old_main(lower=[('DOPC', 72, 0)],
-                                 upper=[('POPC', 89, 0)],
-                                 output='plop.gro', zdistance=15)
+    with utils._redirect_out_and_err(sys.stdout, sys.stdout):
+        (molecules,
+         protein,
+         membrane,
+         solvent,
+         lipids,
+         box) = insane.core.old_main(lower=[('DOPC', 72, 0)],
+                                     upper=[('POPC', 89, 0)],
+                                     output='plop.gro', zdistance=15)
     npo4 = len([atom for atom in membrane.atoms if atom[0] == 'PO4'])
     assert_equal(npo4, 72 + 89)
     assert_equal(molecules, [('POPC', 89), ('DOPC', 72)])
     assert_equal(lipids, ((('DOPC',), (72,), (0,)), (('POPC',), (89,), (0,))))
+    assert_equal(len(protein), 0)
+    assert_equal(len(solvent), 0)
+
+
+def test_absolute_lipid_multi():
+    with utils._redirect_out_and_err(sys.stdout, sys.stdout):
+        (molecules,
+         protein,
+         membrane,
+         solvent,
+         lipids,
+         box) = insane.core.old_main(lower=[('DOPC', 72, 0), ('POPC', 89, 0)],
+                                     output='plop.gro', zdistance=15)
+    npo4 = len([atom for atom in membrane.atoms if atom[0] == 'PO4'])
+    assert_equal(npo4, (72 + 89) * 2)
+    assert_equal(molecules, [('DOPC', 72), ('POPC', 89),
+                             ('DOPC', 72), ('POPC', 89)])
+    assert_equal(lipids, ((('DOPC', 'POPC'), (72, 89), (0, 0)),
+                          (('DOPC', 'POPC'), (72, 89), (0, 0))))
     assert_equal(len(protein), 0)
     assert_equal(len(solvent), 0)

--- a/tests/test_absolute.py
+++ b/tests/test_absolute.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# INSert membrANE
+# A simple, versatile tool for building coarse-grained simulation systems
+# Copyright (C) 2017  Tsjerk A. Wassenaar and contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+"""
+Test that a user can ask for an absolute number of lipids.
+"""
+
+from nose.tools import assert_equal, assert_raises
+import insane
+
+def test_absolute_lipid_only():
+    (molecules,
+     protein,
+     membrane,
+     solvent,
+     lipids,
+     box) = insane.core.old_main(lower=[('DOPC', 72, 0)],
+                                 output='plop.gro', zdistance=15)
+    npo4 = len([atom for atom in membrane.atoms if atom[0] == 'PO4'])
+    assert_equal(npo4, 72 * 2)
+    assert_equal(molecules, [('DOPC', 72), ('DOPC', 72)])
+    assert_equal(lipids, ((('DOPC',), (72,), (0,)), (('DOPC',), (72,), (0,))))
+    assert_equal(len(protein), 0)
+    assert_equal(len(solvent), 0)
+
+
+def test_absolute_lipid_assym():
+    (molecules,
+     protein,
+     membrane,
+     solvent,
+     lipids,
+     box) = insane.core.old_main(lower=[('DOPC', 72, 0)],
+                                 upper=[('POPC', 89, 0)],
+                                 output='plop.gro', zdistance=15)
+    npo4 = len([atom for atom in membrane.atoms if atom[0] == 'PO4'])
+    assert_equal(npo4, 72 + 89)
+    assert_equal(molecules, [('POPC', 89), ('DOPC', 72)])
+    assert_equal(lipids, ((('DOPC',), (72,), (0,)), (('POPC',), (89,), (0,))))
+    assert_equal(len(protein), 0)
+    assert_equal(len(solvent), 0)


### PR DESCRIPTION
Remove debug prints that were breaking the tests. Add specific tests for the absolute number of lipids.