### PR TITLE
Restore iteration over old topology lipids

### DIFF
--- a/insane/core.py
+++ b/insane/core.py
@@ -331,7 +331,7 @@ class Structure(object):
         for idx, (atom, (x, y, z)) in atom_enumeration:
             atname, resname, resid = atom[:3]
             if resname.endswith('.o'):
-                resname = rn[:-2]
+                resname = resname[:-2]
             yield idx, atname, resname, resid, x, y, z
 
     @property


### PR DESCRIPTION
An old variable name was kept breaking iteration on old topology lipid.

Yep. It is a very small PR.

Fixes #51