### PR TITLE
Make resource files available in the zip package

### DIFF
--- a/insane/lipids.py
+++ b/insane/lipids.py
@@ -20,12 +20,13 @@ import collections
 import math
 import os
 
+from . import utils
 
 __all__ = ['Lipid', 'Lipid_List', 'get_lipids']
 
 
 # Lipid data file
-LIPIDFILE = 'lipids.dat'
+LIPID_FILE = 'lipids.dat'
 
 # Define supported lipid head beads. One letter name mapped to atom name
 HEADBEADS = {
@@ -221,36 +222,36 @@ class Lipid_List(collections.MutableMapping):
                                charge=charge)
 
 
-def read_lipids(filename):
+def read_lipids(lipfile):
     lipids = Lipid_List()
-    with open(filename) as lipfile:
-        x, y, z = None, None, None
-        for line in lipfile:
-            stripped = line.strip()
-            if (not stripped) or stripped.startswith((';','#')):
-                # Comment or empty line
-                continue
-            elif stripped.startswith('['):
-                # Moleculetype tag
-                x, y, z = None, None, None
-                # moltype = stripped[2:stripped.find(']')].strip()
-            elif x is None:
-                x = [float(i) for i in line.split() ]
-            elif y is None:
-                y = [float(i) for i in line.split() ]
-            elif z is None:
-                z = [float(i) for i in line.split() ]
-            else:
-                splitted = line.split()
-                name = splitted.pop(0)
-                lipids[name] = Lipid(
-                    name=name, 
-                    beads=splitted, 
-                    template=zip(x, y, z)
-                )
+    x, y, z = None, None, None
+    for line in lipfile:
+        stripped = line.strip()
+        if (not stripped) or stripped.startswith((';','#')):
+            # Comment or empty line
+            continue
+        elif stripped.startswith('['):
+            # Moleculetype tag
+            x, y, z = None, None, None
+            # moltype = stripped[2:stripped.find(']')].strip()
+        elif x is None:
+            x = [float(i) for i in line.split() ]
+        elif y is None:
+            y = [float(i) for i in line.split() ]
+        elif z is None:
+            z = [float(i) for i in line.split() ]
+        else:
+            splitted = line.split()
+            name = splitted.pop(0)
+            lipids[name] = Lipid(
+                name=name, 
+                beads=splitted, 
+                template=zip(x, y, z)
+            )
     return lipids
 
 
 def get_lipids():
-    return read_lipids(os.path.join(os.path.dirname(__file__), LIPIDFILE))
-
+    lipid_stream = utils.iter_resource(LIPID_FILE)
+    lipids = read_lipids(lipid_stream)
+    return lipids

--- a/insane/utils.py
+++ b/insane/utils.py
@@ -1,0 +1,34 @@
+# INSert membrANE
+# A simple, versatile tool for building coarse-grained simulation systems
+# Copyright (C) 2017  Tsjerk A. Wassenaar and contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+Utility functions
+"""
+
+import pkg_resources
+
+def iter_resource(filename):
+    """
+    Return a stream for a given resource file in the module.
+
+    The resource file has to be part of the module and its filenane given
+    relative to the module.
+    """
+    with pkg_resources.resource_stream(__name__, filename) as resource:
+        for line in resource:
+            yield line.decode('utf-8')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# INSert membrANE
+# A simple, versatile tool for building coarse-grained simulation systems
+# Copyright (C) 2017  Tsjerk A. Wassenaar and contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+"""
+Test the functions from insane.utils.
+"""
+
+from insane import utils
+
+def test_open_resource_root():
+    # Test that a ressource at the root of the module can be opened
+    assert list(utils.iter_resource('lipids.dat'))
+
+
+def test_open_resource_nested():
+    # Test that a ressource in a subdirectory of the module can be opened
+    assert list(utils.iter_resource('data/diacylester.dat'))


### PR DESCRIPTION
Non-python files cannot be read in a zip package as they usually are.
Indeed, in a zip package, resource files leave in memory instead of on
the disk. As a result, they do not have a file name and cannot be
opened.

This commit introduces the function `utils.iter_resource` that should be
used to access resource files instead of `open`. It takes the name of the
resource file expressed relative to the module root as an argument and
return an iterator over the lines of the file.