### PR TITLE
Add codecov support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ python:
 install:
     - git clone https://github.com/Tsjerk/simopt.git && pip install ./simopt
     - pip install ./
-    - pip install nose coverage mock
+    - pip install nose coverage mock codecov
 script:
     - |
         cd tests \
         && python run_tests.py -v --with-coverage --cover-package=insane
+after_success:
+    - codecov
 jobs:
     include:
        - stage: package


### PR DESCRIPTION
Codecov is a web service that display code coverage and code coverage
evolution over time. Coverage is calculated during the travis build and
then sent to the codecov server.

An example of the output on insane is visible at
<https://codecov.io/gh/jbarnoud/Insane/tree/5f7ee46f4cbae4456d152dd103139538117402c5>.

**Before** merging this pull request, you should loggin on codecov using github: <https://codecov.io/>.