### PR TITLE
Fixes wrong tail beadnames when adding new lipids

### DIFF
--- a/insane/lipids.py
+++ b/insane/lipids.py
@@ -109,7 +109,7 @@ class Lipid:
                     beads.extend([LINKBEADS[n] + str(i + 1)
                                   for i, n in enumerate(self.link)])
                     for i, t in enumerate(self.tail):
-                        beads.extend([n + chr(65 + i) + str(j + 1)
+                        beads.extend([n + str(j + 1) + chr(65 + i)
                                       for j, n in enumerate(t)])
 
                 taillength = max([0]+[len(i) for i in self.tail])


### PR DESCRIPTION
When adding new lipids with the `-al*` flags, the tail names would get mangled: beads `C1A`, `C2A`, etc. become `CA1`, `CA2`, etc.

It is a simple matter of swapped letter/number in the bead naming.