### PR TITLE
Correctly handle Martini GO sites

### DIFF
--- a/insane/structure.py
+++ b/insane/structure.py
@@ -143,12 +143,12 @@ class Structure(object):
 
     @property
     def charge(self):
-        last = None
         charge = 0
+        seen = set()
         for j in self.atoms:
-            if not j[0].strip().startswith('v') and j[1:3] != last:
+            if not j[0].strip().startswith('v') and j[1:4] not in seen:
                 charge += CHARGES.get(j[1].strip(), 0)
-            last = j[1:3]
+            seen.add(j[1:4])
         return charge
 
     @property


### PR DESCRIPTION
This PR lets Insane correctly determine charge when GO virtual sites are present in the PDB file.

Because these atoms are placed at the end of the PDB file, charged residues can be double counted.

To handle this, we check if a (resname, resid, chain) has been seen and only increment the charge counter when it is unseen.