### PR TITLE
Reword the README to reflect the current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ include Martini water. The total amount is defined from the free volume of the
 box, and the solvent diameter (0.5 nm per default).
 
 The `-o` and `-p` arguments specify the output of the program. With `-o
-bilayer.gro`, insane will write the system structure in a [GRO
-file](http://manual.gromacs.org/current/online/gro.html) usable with
-[gromacs][]. Insane can also write PDB files if the output file has the `.pdb`
-file extension. With `-p topol.top`, insane will write a template TOP file to
-be used with gromacs. If the `-p` argument is omitted, insane writes the
+bilayer.gro`, insane will write the system structure in a [GRO file][] usable
+with [gromacs][]. Insane can also write PDB files if the output file has the
+`.pdb` file extension. With `-p topol.top`, insane will write a template TOP
+file to be used with gromacs. If the `-p` argument is omitted, insane writes the
 content of the system on the standard output in a form that can be appended at
 the end of an existing TOP file.
+
+[GRO file]: https://manual.gromacs.org/current/reference-manual/file-formats.html#gro
 
 ### Create a more complex bilayer
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ box, and the solvent diameter (0.5 nm per default).
 The `-o` and `-p` arguments specify the output of the program. With `-o
 bilayer.gro`, insane will write the system structure in a [GRO
 file](http://manual.gromacs.org/current/online/gro.html) usable with
-[gromacs][]. Insane can also write PDB files if the output file has the '.pdb'
+[gromacs][]. Insane can also write PDB files if the output file has the `.pdb`
 file extension. With `-p topol.top`, insane will write a template TOP file to
 be used with gromacs. If the `-p` argument is omitted, insane writes the
 content of the system on the standard output in a form that can be appended at
@@ -110,7 +110,7 @@ with `-box`, or setting the box geometry with `-pbc`, overwrite that default.
 If the `-salt` argument is set, insane will add ions to the system. With
 `-salt` set to 0, insane will add enough chloride or sodium ions to
 neutralize the system charge. If `-salt` is set to any positive value, it is
-read as the concentration of ions in molar.
+read as the molar concentration of ions.
 
 ### Insert a protein in a membrane
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ composed of 90% of regular Martini water and 10% Martini anti-freeze water.
 
 Insane can setup protein systems. Here we create a box of solvent around
 a protein. Note that insane does not prepare the protein itself. Use
-[martinize](http://cgmartini.nl/index.php/tools2/proteins-and-bilayers) to
-coarse grain a protein structure.
+[martinize2](https://github.com/marrink-lab/vermouth-martinize) to prepare a
+coarse grain protein structure.
 
 ```bash
 insane -o system.gro -p topol.top -f protein.pdb -d 7 -sol W -salt 0

--- a/README.md
+++ b/README.md
@@ -131,15 +131,50 @@ box along the Z axis with the `-center` argument.
 With the `-pbc` option we set the shape of the periodic box to a prism with
 a hexagonal base.
 
-### Changing templates
+### Solvent mixtures
 
-Templates for both Martini 2 and 3 molecules are predefined within insane, use the `-ff M2` or `-ff M3` to switch between them. Specific template versions can also be specified directly in the lipid name e.g. use `-l M3.POPC` instead of `-l POPC`.
+In the same way multiple lipids can be provided to set up complex lipid
+bilayers, mixtures of solvent beads can be made.
 
-#### Custom lipid definitions
+This is particularly useful when building a Martini 2 system, which requires
+solvation using normal (W) and anti-freeze waters (WF).
 
-The default definitions of lipid templates are stored in the `insane/lipids.dat` file.
+```bash
+insane \
+    -o system.gro -p topol.top \
+    -ff M2 \
+    -d 10 -l POPC \
+    -f protein.gro -center \
+    -sol W:90 -sol WF:10
+```
 
-A custom `lipids.dat` file can be added using the `-dat` option. For example, if you have a custom lipids file called `custom.dat` that defines the special lipid `ABCD`, you can use it as follows.
+This will set up a bilayer around a membrane protein and solvate the system with
+90% normal waters, and with 10% anti-freeze waters.
+
+Also note that the Martini 2 force field was selected using the `-ff M2` option.
+
+### Selecting the lipid template force field
+
+By default, insane will set up a Martini 3 system. This means that it draws from
+Martini 3 lipid definitions. To change this, the `-ff M2` option can be used to
+select Martini 2 lipids.
+
+Lipids in lipids data files (e.g., `lipids.dat`) are prefixed by `M2.` or `M3.`
+to indicate the force field version. To select a lipid with a particular force
+field prefix directly, you can provide its fully specified name, which will
+override the prefix given by the `-ff` option. For example, `M2.CHOL`,
+`M3.CHOL`, and `M3d.CHOL` all refer to different cholesterol topologies. When
+using `-ff M3` (the default value), you need to use the `M3d` prefix explicitly
+to select that variant: `-l M3d.CHOL`.
+
+### Adding custom lipid definitions
+
+The default definitions of lipid templates are stored in the `insane/lipids.dat`
+file.
+
+A custom `lipids.dat` file can be added using the `-dat` option. For example, if
+you have a custom lipids file called `custom.dat` that defines the special lipid
+`ABCD`, you can use it as follows.
 
 ```bash
 insane \

--- a/README.md
+++ b/README.md
@@ -186,18 +186,23 @@ insane \
 
 If the additional lipids file contains names that already exist, the previous definitions will be overwritten.
 
-## Get help
+## Learn
 
-Get the list of all the arguments by running `insane -h`.
+Get usage information by running `insane -h`.
 
-You can get additional help in the ["Tools" section of the Martini
-forum](http://cgmartini.nl/index.php/component/kunena/9-tools).
+A number of tutorials using insane are available, including:
 
-As well as access tutorials using insane in [Martini 2 membrane tutorials](http://www.cgmartini.nl/index.php/tutorials-general-introduction-gmx5/bilayers-gmx5) and [Martini 3 membrane tutorials](https://doi.org/10.1016/bs.mie.2024.03.010).
+- Hands-on Martini 3 tutorial: [**Lipid bilayers: Complex mixtures**](https://cgmartini.nl/docs/tutorials/Martini3/LipidsII/)
+- Book chapter: [**Building complex membranes with Martini 3**](https://doi.org/10.1016/bs.mie.2024.03.010)
+
+  > Ozturk, T. N., König, M., Carpenter, T. S., Pedersen, K. B., Wassenaar, T. A., Ingólfsson, H. I.,
+  > & Marrink, S. J. (2024). Building complex membranes with Martini 3. In _Methods in Enzymology_
+  > (Vol. 701, pp. 237-285). Academic Press.
+  > <https://doi.org/10.1016/bs.mie.2024.03.010>
 
 ## Contribute
 
 Insane is hosted on [Github](https://github.com/Tsjerk/Insane). Please, report
-there any [issue](https://github.com/Tsjerk/Insane/issues) you encounter.
+any [issue](https://github.com/Tsjerk/Insane/issues) you encounter.
 
 [gromacs]: http://www.gromacs.org

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ line:
 insane \
     -f cg1a0s.pdb \
     -l POPC \
-    -sol W:90 -sol WF:10 \
-    -salt 0.8 \
+    -sol W \
+    -salt 0.15 \
     -o system.gro -p topol.top
 ```
 
@@ -107,7 +107,7 @@ insane \
     -o bilayer.gro -p topol.top \
     -x 20 -y 20 -z 10 \
     -l DPPC:4 -l DIPC:3 -l CHOL:3 \
-    -sol W:90 -sol WF:10
+    -sol W
 ```
 
 The periodic box can be defined in multiple ways. Here we build an orthorhombic
@@ -153,16 +153,12 @@ system, we can insert a protein in a lipid bilayer.
 insane \
     -o system.gro -p topol.top \
     -d 10 -pbc hexagonal \
-    -l POPC -sol PW \
+    -l POPC -sol W \
     -f protein.gro -center
 ```
 
 Here, the protein structure we give with the `-f` argument is centered in the
 box along the Z axis with the `-center` argument.
-
-We build this system with [Martini polarizable
-water](http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1000810)
-using `-sol PW`.
 
 With the `-pbc` option we set the shape of the periodic box to a prism with
 a hexagonal base.

--- a/README.md
+++ b/README.md
@@ -20,26 +20,6 @@ insane \
 
 ## Installation
 
-Insane can be installed either as a single-file program, or as a python module.
-
-### Install insane as a single-file program
-
-Insane depends on python (either version 2 or 3) and on the numpy python library. Make sure you
-have these two requirements installed:
-
-```bash
-python -c 'import numpy'
-```
-
-If this command line outputs an error message, you need to instal either python
-or numpy.
-
-Download the [latest version of
-insane](https://github.com/Tsjerk/Insane/releases/download/v1.0rc1/insane) as
-a single executable.
-
-Run insane: `./insane -h`.
-
 ### Install insane as a python module
 
 Insane is available on [pypi](https://pypi.python.org/pypi/insane/1.0rc1) and

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ bilayer.gro`, insane will write the system structure in a [GRO
 file](http://manual.gromacs.org/current/online/gro.html) usable with
 [gromacs][]. Insane can also write PDB files if the output file has the '.pdb'
 file extension. With `-p topol.top`, insane will write a template TOP file to
-be used with [gromacs][]. If the `-p` argument is omitted, insane writes the
+be used with gromacs. If the `-p` argument is omitted, insane writes the
 content of the system on the standard output in a form that can be appended at
 the end of an existing TOP file.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,12 @@ insane \
     -l ABCD -d 10
 ```
 
-If the additional lipids file contains names that already exist, the previous definitions will be overwritten.
+If the additional lipids file contains names that already exist, the previous
+definitions will be overwritten.
+
+In previous versions, the `lipids.dat` file in the insane package path had to be
+edited to add or change lipid template definitions. The `-dat` flag makes this
+process much more convenient and flexible.
 
 ## Learn
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ the end of an existing TOP file.
 
 Insane can build lipid mixtures. Here we build a ternary mixture containing
 a fully saturated lipid (DPPC), a polyunsaturated lipid
-(dilinoleyl-phosphatidylcholine, called DIPC in the Martini force field), and
+(diloleoyl-phosphatidylcholine, called DOPC in the Martini force field), and
 cholesterol.
 
 ```bash
 insane \
     -o bilayer.gro -p topol.top \
     -x 20 -y 20 -z 10 \
-    -l DPPC:4 -l DIPC:3 -l CHOL:3 \
+    -l DPPC:4 -l DOPC:3 -l CHOL:3 \
     -sol W
 ```
 
@@ -84,7 +84,7 @@ box by setting the X, Y, and Z axes separately with `-x`, `-y`, and `-z`,
 respectively.
 
 The `-l` option can be provided multiple times to setup multiple lipid types.
-Here we setup DPPC, DIPC, and cholesterol with a 4:3:3 ratio.
+Here we setup DPPC, DOPC, and cholesterol with a 4:3:3 ratio.
 
 The `-sol` option can also be provided multiple times. Here the solvent is
 composed of 90% of regular Martini water and 10% Martini anti-freeze water.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ coarse grain a protein structure.
 ```bash
 insane -o system.gro -p topol.top -f protein.pdb -d 7 -sol W -salt 0
 ```
+
 Solutes, including proteins, can be read from a GRO or a PDB file provided with
 the `-f` argument.
 
@@ -166,9 +167,9 @@ using `-sol PW`.
 With the `-pbc` option we set the shape of the periodic box to a prism with
 a hexagonal base.
 
-### Changing templates 
+### Changing templates
 
-Templates for both Martini 2 and 3 molecules are predefined within insane, use the `-ff M2` or `-ff M3` to switch between them. Specific template versions can also be specified directly in the lipid name e.g. use `-l M3.POPC` instead of `-l POPC`. 
+Templates for both Martini 2 and 3 molecules are predefined within insane, use the `-ff M2` or `-ff M3` to switch between them. Specific template versions can also be specified directly in the lipid name e.g. use `-l M3.POPC` instead of `-l POPC`.
 
 #### Custom lipid definitions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Insane - A simple, versatile tool for building coarse-grained simulation systems
 
-[![Build Status](https://travis-ci.org/Tsjerk/Insane.svg?branch=master)](https://travis-ci.org/Tsjerk/Insane)
-
 Insane (INSert membrANE) is a versatile tool to build coarse-grained simulation
 systems containing solutes, lipid bilayers, and/or solvents. It is initially
 aimed at the [Martini force field](http://cgmartini.nl) but can be used for

--- a/README.md
+++ b/README.md
@@ -20,28 +20,16 @@ insane \
 
 ## Installation
 
-### Install insane as a python module
-
-Insane is available on [pypi](https://pypi.python.org/pypi/insane/1.0rc1) and
-can be installed using pip. To install insane for the current user, run
+Insane is available on [pypi](https://pypi.python.org/pypi/insane) and
+can be installed using `pip`.
 
 ```bash
-pip install --user insane
+pip install insane
 ```
 
-Pip installs the insane in `~/.local/lib/python<version>/site-packages`,
-where `<version>` is the version of python. Check that the
-directory exists and that it is in your `PYTHONPATH`. The insane program is
-installed in `~/.local/bin`, make sure this directory is in your `PATH`.
-
-To install insane system wide, run
-
-```bash
-sudo pip install insane
-```
-
-We recommend the use of python virtual environments. Read more about them on
-the [MDAnalysis website](http://www.mdanalysis.org/2017/04/07/environments/).
+We recommend the use of python _virtual environments_. The documentation for
+[`venv`](https://docs.python.org/3/library/venv.html) is quite helpful, but many other methods for
+using virtual environments are available.
 
 ## Quick start
 


### PR DESCRIPTION
This is a pile of commits where I rework the README to reflect the current state and operation of _insane_.

The most important changes are in the installation procedures and the example invocations. The goal here is to get everything in line for presenting `pip install insane` as the blessed and updated method for installing the tool, and to make the examples `-ff M3` compatible, since it's the default since a long while.

Remember: these are just suggestions.

Here is my terse todo list for these changes:

### README

- [x] Failing build indicator should go.
- Maybe all automated CI stuff should go, it's old and defunct. We can resurrect it another time.
- [x] More Martini 3 example (no more -sol WF).
- [x] Remove idea of insane as a single-file program.
- [x] Simple, clear pip install guidance. 
      No `--user`, no `sudo pip install`.
- [x] Check and automatically test the Quick start 
      guide in the README.
- [x] Add documentation on the `-ff` flag.
- [x] Polarizable water? Nah, right?

#### Fix the links

- [x] Dead link to the Martini forum.
- [x] Dead link to Martini 2 tutorial.
- [x] Better link to the Martini 3 membrane tutorial book chapter.
- [x] Link the cgmartini.nl tutorial. 
      <https://cgmartini.nl/docs/tutorials/Martini3/LipidsII/>
- [x] PyPI link.
- [x] MDAnalysis virtual environment link.
- [x] Gro file manual link 404.
- [x] Links to gromacs too much?
- [x] Martinize link